### PR TITLE
Fix for negative values on gas return temp

### DIFF
--- a/src/CN105_Gateway.ino
+++ b/src/CN105_Gateway.ino
@@ -454,12 +454,11 @@ void parsePacketItem(byte *packet, char *jsonStr, byte item)
 void parseTemperature(byte *packet, byte varIndex, char *textStr)
 {
   float temperature;
-  float msb = 0;
-  float lsb = 0;
-  msb = packet[varIndex];
-  lsb = packet[varIndex + 1];
-  temperature = (msb * 256 + lsb) / 100;
-  sprintf(textStr, "%2.1f", temperature);
+  int16_t temp = 0;
+  temp = packet[varIndex + 1];
+  temp |= packet[varIndex] << 8;
+  temperature = (float)temp / 100;
+  snprintf(textStr, 7, "%2.1f", temperature);
 }
 void parseTimeDate(byte *packet, byte varIndex, char *textStr)
 {


### PR DESCRIPTION
Noticed that gas return would go to +600C when it should have been negative